### PR TITLE
Improve mobile layout and sample PDF support

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,48 +1,78 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
-  margin: 2em;
+  margin: 1em;
   background-color: #f8f8f8;
 }
+
 h1 {
   text-align: center;
   color: #333;
 }
-.sample-buttons button, button {
+
+.sample-buttons button,
+button {
   padding: 0.5em 1em;
   font-size: 1em;
   cursor: pointer;
 }
+
 .viewer-container {
   display: flex;
-  gap: 2em;
+  flex-wrap: wrap;
+  gap: 1em;
   margin-top: 1em;
 }
+
 .viewer-container iframe {
+  flex: 1 1 300px;
   border: 1px solid #ccc;
   background: white;
   box-shadow: 0 0 5px rgba(0,0,0,0.1);
+  min-height: 400px;
 }
+
 .results-panel {
-  width: 45%;
+  flex: 1 1 300px;
   background: white;
   padding: 1em;
   box-shadow: 0 0 5px rgba(0,0,0,0.1);
 }
+
 pre {
   background: #efefef;
   padding: 0.5em;
   overflow-x: auto;
 }
+
 .sample-buttons button {
   margin-right: 1em;
 }
+
 footer {
   margin-top: 3em;
   font-size: 0.9em;
   color: #666;
+  text-align: center;
 }
+
 .hint {
   margin-top: 1em;
   color: #007700;
   font-weight: bold;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  body {
+    margin: 0.5em;
+  }
+  .viewer-container {
+    flex-direction: column;
+  }
+  iframe {
+    width: 100%;
+  }
+  .results-panel {
+    width: 100%;
+  }
 }

--- a/static/viewer.js
+++ b/static/viewer.js
@@ -24,4 +24,14 @@ function loadSample(path) {
   pdfViewer.src = path;
   resultsBox.textContent = "Click 'Upload' to analyze this sample document.";
   summaryText.textContent = "";
+
+  // Fetch the sample PDF and populate the file input so it can be uploaded
+  fetch(path)
+    .then((res) => res.blob())
+    .then((blob) => {
+      const file = new File([blob], path.split('/').pop(), { type: 'application/pdf' });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      fileInput.files = dt.files;
+    });
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <title>Transaction Data Extraction Model</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/static/style.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- make layout mobile-friendly with a responsive stylesheet
- set viewport meta tag in the page header
- allow sample buttons to populate the file input so uploading works

## Testing
- `python -m py_compile main.py extract_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a5733f80c8325aea6f9991e7ac0a6