### PR TITLE
Fix metadata loading and vectorization for new model format

### DIFF
--- a/extract_model.py
+++ b/extract_model.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+import json
 from catboost import CatBoostRegressor, CatBoostClassifier
 import fitz  # PyMuPDF
 
@@ -17,19 +18,25 @@ models = {
     "fee_currency": CatBoostClassifier().load_model(os.path.join(MODEL_DIR, "fee_currency_model.cbm")),
 }
 
-# Load metadata (e.g., vectorizer)
-with open(os.path.join(MODEL_DIR, "metadata.pkl"), "rb") as f:
-    metadata = pickle.load(f)
+# Load metadata that describes where the encoder pickle files live
+with open(os.path.join(MODEL_DIR, "metadata.json"), "r") as f:
+    metadata = json.load(f)
 
-# Models were trained directly on raw text features so no vectorizer is needed
-# Older versions of the metadata contained a serialized TfidfVectorizer, but the
-# current model artifacts omit it. Predictions are made by passing the document
-# text directly to each CatBoost model.
-label_encoders = metadata["label_encoders"]  # dict mapping field -> {label_to_int, int_to_label}
+# Load each label encoder referenced in the metadata
+label_encoders = {}
+for field, enc_file in metadata.get("encoders_files", {}).items():
+    with open(os.path.join(MODEL_DIR, enc_file), "rb") as ef:
+        label_encoders[field] = pickle.load(ef)
 
-def _decode_label(encoder_dict, value):
+# Load TfidfVectorizer used to transform the document text before prediction
+with open(os.path.join(MODEL_DIR, metadata["tfidf_file"]), "rb") as f:
+    vectorizer = pickle.load(f)
+
+def _decode_label(encoder, value):
     """Decode integer predictions back to their string labels."""
-    return encoder_dict["int_to_label"].get(int(value), "")
+    # Predictions may be floats; round and cast to int for inverse_transform
+    idx = int(round(float(value)))
+    return encoder.inverse_transform([idx])[0]
 
 def extract_fields_from_pdf(pdf_path):
     # Extract raw text from PDF
@@ -37,25 +44,27 @@ def extract_fields_from_pdf(pdf_path):
     full_text = "\n".join([page.get_text() for page in doc])
     doc.close()
 
-    # Pass the raw text directly to the models
+    # Vectorize the text for the CatBoost models
+    features = vectorizer.transform([full_text])
+
     result = {
-        "amount_before": float(models["amount_before"].predict([full_text])),
+        "amount_before": float(models["amount_before"].predict(features)),
         "from_currency": _decode_label(
             label_encoders["from_currency"],
-            models["from_currency"].predict([full_text])[0],
+            models["from_currency"].predict(features)[0],
         ),
         "to_currency": _decode_label(
             label_encoders["to_currency"],
-            models["to_currency"].predict([full_text])[0],
+            models["to_currency"].predict(features)[0],
         ),
-        "exchange_rate": float(models["exchange_rate"].predict([full_text])),
-        "fee": float(models["fee"].predict([full_text])),
+        "exchange_rate": float(models["exchange_rate"].predict(features)),
+        "fee": float(models["fee"].predict(features)),
         "fee_currency": _decode_label(
             label_encoders["fee_currency"],
-            models["fee_currency"].predict([full_text])[0],
+            models["fee_currency"].predict(features)[0],
         ),
-        "amount_converted": float(models["amount_converted"].predict([full_text])),
-        "after_fee": float(models["after_fee"].predict([full_text])),
+        "amount_converted": float(models["amount_converted"].predict(features)),
+        "after_fee": float(models["after_fee"].predict(features)),
         "raw_text": full_text[:1000] + "..." if len(full_text) > 1000 else full_text
     }
 


### PR DESCRIPTION
## Summary
- handle JSON metadata structure
- load separate label encoders and TF‑IDF vectorizer
- vectorize text before predicting

## Testing
- `python -m py_compile main.py extract_model.py`
- `pytest -q`
- `python - <<'EOF'
from extract_model import extract_fields_from_pdf
print(extract_fields_from_pdf('static/sample1.pdf'))
print(extract_fields_from_pdf('static/sample2.pdf'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688a65e721648325859063a5fe43b13b