### PR TITLE
Improve PDF field extraction

### DIFF
--- a/extract_model.py
+++ b/extract_model.py
@@ -1,6 +1,9 @@
 import os
 import pickle
 import json
+import re
+from typing import Optional
+from datetime import datetime
 from catboost import CatBoostRegressor, CatBoostClassifier
 import fitz  # PyMuPDF
 
@@ -31,6 +34,84 @@ for field, enc_file in metadata.get("encoders_files", {}).items():
 # Load TfidfVectorizer used to transform the document text before prediction
 with open(os.path.join(MODEL_DIR, metadata["tfidf_file"]), "rb") as f:
     vectorizer = pickle.load(f)
+
+
+def _parse_number(num_str: str) -> Optional[float]:
+    """Convert a numeric string with optional commas into a float."""
+    try:
+        return float(num_str.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _parse_date(date_str: str) -> Optional[str]:
+    """Parse a date like 8/2/2023 into ISO format."""
+    for fmt in ("%m/%d/%Y", "%d/%m/%Y", "%m/%d/%y", "%d/%m/%y"):
+        try:
+            return datetime.strptime(date_str, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return None
+
+
+def _heuristic_extract(text: str) -> dict:
+    """Best-effort extraction using regex patterns."""
+    result: dict = {}
+
+    # Wire or transfer amounts
+    amount_matches = list(
+        re.finditer(r"Wire Amount\s*\((?P<cur>[A-Za-z]{3})\):\s*(?P<num>[\d,]+(?:\.\d+)?)",
+                    text, re.IGNORECASE)
+    )
+    if not amount_matches:
+        # Alternate Western Union style
+        alt = re.search(r"([\d,.]+)\s*(?P<cur>[A-Za-z]{3})\s*Transfer amount", text, re.IGNORECASE)
+        if alt:
+            amount_matches.append(alt)
+        alt_conv = re.search(r"([\d,.]+)\s*(?P<cur>[A-Za-z]{3})\s*Total to receiver", text, re.IGNORECASE)
+        if alt_conv:
+            amount_matches.append(alt_conv)
+
+    if amount_matches:
+        first = amount_matches[0]
+        num = first.group("num") if "num" in first.groupdict() else first.group(1)
+        cur = first.group("cur").upper()
+        result["amount_before"] = _parse_number(num)
+        result["from_currency"] = cur
+        if len(amount_matches) > 1:
+            second = amount_matches[1]
+            num2 = second.group("num") if "num" in second.groupdict() else second.group(1)
+            cur2 = second.group("cur").upper()
+            result["amount_converted"] = _parse_number(num2)
+            result["to_currency"] = cur2
+
+    # Exchange rate
+    m = re.search(r"([\d,.]+)\s*[A-Za-z]{3}\s*=\s*([\d,.]+)\s*[A-Za-z]{3}", text)
+    if m:
+        result["exchange_rate"] = _parse_number(m.group(2))
+    else:
+        m = re.search(r"Exchange Rate[:\s]*([\d.]+)", text, re.IGNORECASE)
+        if m:
+            result["exchange_rate"] = _parse_number(m.group(1))
+
+    # Wire fee
+    m = re.search(r"Wire Fee\s*\((?P<cur>[A-Za-z]{3})\):\s*(?P<num>[\d,]+(?:\.\d+)?)",
+                  text, re.IGNORECASE)
+    if not m:
+        m = re.search(r"([\d,.]+)\s*(?P<cur>[A-Za-z]{3})\s*Transfer fee", text, re.IGNORECASE)
+    if m:
+        num = m.group("num") if "num" in m.groupdict() else m.group(1)
+        result["fee"] = _parse_number(num)
+        result["fee_currency"] = m.group("cur").upper()
+
+    # Date
+    m = re.search(r"Wire Date[:\s]*([0-9]{1,2}/[0-9]{1,2}/[0-9]{2,4})", text, re.IGNORECASE)
+    if m:
+        parsed = _parse_date(m.group(1))
+        if parsed:
+            result["date"] = parsed
+
+    return result
 
 def _decode_label(encoder, value):
     """Decode integer predictions back to their string labels."""
@@ -67,5 +148,9 @@ def extract_fields_from_pdf(pdf_path):
         "after_fee": float(models["after_fee"].predict(features)),
         "raw_text": full_text[:1000] + "..." if len(full_text) > 1000 else full_text
     }
+
+    # Use regex heuristics to override predictions when obvious values exist
+    heuristics = _heuristic_extract(full_text)
+    result.update({k: v for k, v in heuristics.items() if v is not None})
 
     return result


### PR DESCRIPTION
## Summary
- add regex-based parsing logic for numeric fields in PDFs
- fall back to ML predictions when no regex match is found

## Testing
- `python extract_model.py` sample function on `static/sample2.pdf`
- `python extract_model.py` sample function on `static/sample1.pdf`


------
https://chatgpt.com/codex/tasks/task_e_688a720514f88325a03f57e1bdab7ffd