### PR TITLE
Improve PDF viewer layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,7 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
-  margin: 1em;
+  margin: 0;
+  padding: 0 1em;
   background-color: #f8f8f8;
 }
 
@@ -30,32 +31,37 @@ button {
   cursor: pointer;
 }
 
+
 .viewer-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1em;
   margin-top: 1em;
-  align-items: flex-start;
 }
 
-.viewer-container iframe {
-  flex: 1 1 300px;
+
+.pdf-panel,
+.results-panel {
+  display: flex;
+  flex-direction: column;
+  height: 70vh;
+  background: white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+  padding: 1em;
+}
+
+.pdf-panel iframe {
+  flex: 1;
+  width: 100%;
   border: 1px solid #ccc;
   background: white;
-  box-shadow: 0 0 5px rgba(0,0,0,0.1);
-  min-height: 400px;
 }
 
-.results-panel {
-  flex: 1 1 300px;
-  background: white;
-  padding: 1em;
-  box-shadow: 0 0 5px rgba(0,0,0,0.1);
-}
-
-pre {
+.results-panel pre {
+  flex: 1;
   background: #efefef;
   padding: 0.5em;
-  overflow-x: auto;
+  overflow: auto;
 }
 
 .sample-buttons button {
@@ -81,13 +87,10 @@ footer {
     margin: 0.5em;
   }
   .viewer-container {
-    flex-direction: column;
+    grid-template-columns: 1fr;
   }
-  iframe {
-    width: 100%;
-  }
+  .pdf-panel,
   .results-panel {
-    width: 100%;
-    order: -1;
+    height: auto;
   }
 }

--- a/static/viewer.js
+++ b/static/viewer.js
@@ -30,7 +30,7 @@ async function analyzeCurrentFile() {
   pdfViewer.src = data.pdf_path;
   resultsBox.textContent = JSON.stringify(data.fields, null, 2);
   summaryText.textContent =
-    "These fields can be used to estimate how much you could save with better rates.";
+    "These fields show how much you can save when using better rates.";
 }
 
 form.addEventListener("submit", async (e) => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,12 +7,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
 </head>
 <body>
-  <h1>Transaction Data Extraction Model</h1>
-  <p class="instructions">
-    Upload a money transfer PDF to see the extracted fields on the right. You can
-    also load one of the samples below. The file you choose will be sent to the
-    server for analysis and displayed alongside the results.
-  </p>
+  <header>
+    <h1>Transaction Data Extraction Model</h1>
+    <p class="instructions">
+      Upload a money transfer PDF to see the extracted fields. You can also
+      load a sample below. Your file will be sent to the server for analysis and
+      displayed alongside the results.
+    </p>
+  </header>
   <div class="controls">
     <form id="uploadForm">
       <input type="file" id="fileInput" name="file" accept="application/pdf">
@@ -24,12 +26,15 @@
     </div>
   </div>
   <div class="viewer-container">
-    <iframe id="pdfViewer" height="600px"></iframe>
-    <div class="results-panel" id="resultsBox">
+    <section class="pdf-panel">
+      <h2>PDF Preview</h2>
+      <iframe id="pdfViewer" height="600"></iframe>
+    </section>
+    <section class="results-panel" id="resultsBox">
       <h2>Extracted Fields</h2>
       <pre id="results"></pre>
       <p class="hint" id="summaryText"></p>
-    </div>
+    </section>
   </div>
   <footer>
     <p>Sample PDFs are shared under Scribd's fair use terms and are intended solely for demonstration purposes.</p>


### PR DESCRIPTION
## Summary
- redesign index page with clearer layout and pdf heading
- keep PDF viewer full width with side panel results
- update copy to emphasize how much users can save
- refine message about translating fields for savings

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688b56d126648325af5825655173df89