### PR TITLE
Auto scroll to results on mobile

### DIFF
--- a/static/viewer.js
+++ b/static/viewer.js
@@ -3,6 +3,7 @@ const fileInput = document.getElementById("fileInput");
 const resultsBox = document.getElementById("results");
 const pdfViewer = document.getElementById("pdfViewer");
 const summaryText = document.getElementById("summaryText");
+const resultsPanel = document.getElementById("resultsBox");
 
 async function analyzeCurrentFile() {
   if (!fileInput.files.length) {
@@ -31,6 +32,10 @@ async function analyzeCurrentFile() {
   resultsBox.textContent = JSON.stringify(data.fields, null, 2);
   summaryText.textContent =
     "These fields can be translated and used in your application to calculate how much you can save.";
+
+  if (window.innerWidth <= 768) {
+    resultsPanel.scrollIntoView({ behavior: "smooth" });
+  }
 }
 
 form.addEventListener("submit", async (e) => {


### PR DESCRIPTION
## Summary
- smooth scroll to the results after analyzing a file when on mobile screens

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bbf40a34c8325828faf91afb4cfeb